### PR TITLE
Allow to cache the found element.

### DIFF
--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Applications/Startup.cs
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Applications/Startup.cs
@@ -32,6 +32,7 @@ namespace Aquality.Selenium.Core.Applications
 
             services.AddSingleton(settingsFile);
             services.AddSingleton(Logger.Instance);
+            services.AddSingleton<IElementCacheConfiguration, ElementCacheConfiguration>();
             services.AddSingleton<ILoggerConfiguration, LoggerConfiguration>();
             services.AddSingleton<ITimeoutConfiguration, TimeoutConfiguration>();
             services.AddSingleton<IRetryConfiguration, RetryConfiguration>();

--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Aquality.Selenium.Core.xml
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Aquality.Selenium.Core.xml
@@ -51,6 +51,27 @@
             </summary>
             <returns>An instance of settings</returns>
         </member>
+        <member name="T:Aquality.Selenium.Core.Configurations.ElementCacheConfiguration">
+            <summary>
+            Provides element's cache configuration
+            </summary>
+        </member>
+        <member name="M:Aquality.Selenium.Core.Configurations.ElementCacheConfiguration.#ctor(Aquality.Selenium.Core.Configurations.ISettingsFile)">
+            <summary>
+            Instantiates class using <see cref="T:Aquality.Selenium.Core.Configurations.ISettingsFile"/> with general settings.
+            </summary>
+            <param name="settingsFile">Settings file.</param>
+        </member>
+        <member name="T:Aquality.Selenium.Core.Configurations.IElementCacheConfiguration">
+            <summary>
+            Represents element's cache configuration.
+            </summary>
+        </member>
+        <member name="P:Aquality.Selenium.Core.Configurations.IElementCacheConfiguration.Enable">
+            <summary>
+            Is element caching allowed or not.
+            </summary>
+        </member>
         <member name="T:Aquality.Selenium.Core.Configurations.ILoggerConfiguration">
             <summary>
             Describes logger configuration.
@@ -290,6 +311,28 @@
             <summary>
             Clicks the element.
             </summary>
+        </member>
+        <member name="T:Aquality.Selenium.Core.Elements.Interfaces.IElementCacheHandler">
+            <summary>
+            Allows to use cached element.
+            </summary>
+        </member>
+        <member name="P:Aquality.Selenium.Core.Elements.Interfaces.IElementCacheHandler.IsRefreshNeeded">
+            <summary>
+            Determines is the cached element refresh needed.
+            </summary>
+        </member>
+        <member name="P:Aquality.Selenium.Core.Elements.Interfaces.IElementCacheHandler.IsStale">
+            <summary>
+            Determines is the element stale.
+            </summary>
+        </member>
+        <member name="M:Aquality.Selenium.Core.Elements.Interfaces.IElementCacheHandler.GetElement(System.Nullable{System.TimeSpan})">
+            <summary>
+            Allows to get cached element.
+            </summary>
+            <param name="timeout">Timeout used to retrive the element when <see cref="P:Aquality.Selenium.Core.Elements.Interfaces.IElementCacheHandler.IsRefreshNeeded"/> is true.</param>
+            <returns>Cached element.</returns>
         </member>
         <member name="T:Aquality.Selenium.Core.Elements.Interfaces.IElementFactory">
             <summary>

--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Aquality.Selenium.Core.xml
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Aquality.Selenium.Core.xml
@@ -67,7 +67,7 @@
             Represents element's cache configuration.
             </summary>
         </member>
-        <member name="P:Aquality.Selenium.Core.Configurations.IElementCacheConfiguration.Enable">
+        <member name="P:Aquality.Selenium.Core.Configurations.IElementCacheConfiguration.IsEnabled">
             <summary>
             Is element caching allowed or not.
             </summary>

--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Configurations/ElementCacheConfiguration.cs
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Configurations/ElementCacheConfiguration.cs
@@ -11,10 +11,10 @@
         /// <param name="settingsFile">Settings file.</param>
         public ElementCacheConfiguration(ISettingsFile settingsFile)
         {
-            var jPath = $".elementCache.{nameof(Enable).ToLower()}";
-            Enable = settingsFile.IsValuePresent(jPath) && settingsFile.GetValue<bool>(jPath);
+            var jPath = ".elementCache.isEnabled";
+            IsEnabled = settingsFile.IsValuePresent(jPath) && settingsFile.GetValue<bool>(jPath);
         }
 
-        public bool Enable { get; }
+        public bool IsEnabled { get; }
     }
 }

--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Configurations/ElementCacheConfiguration.cs
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Configurations/ElementCacheConfiguration.cs
@@ -1,0 +1,20 @@
+﻿namespace Aquality.Selenium.Core.Configurations
+{
+    /// <summary>
+    /// Provides element's cache configuration
+    /// </summary>
+    public class ElementCacheConfiguration : IElementCacheConfiguration
+    {
+        /// <summary>
+        /// Instantiates class using <see cref="ISettingsFile"/> with general settings.
+        /// </summary>
+        /// <param name="settingsFile">Settings file.</param>
+        public ElementCacheConfiguration(ISettingsFile settingsFile)
+        {
+            var jPath = $".elementCache.{nameof(Enable).ToLower()}";
+            Enable = settingsFile.IsValuePresent(jPath) && settingsFile.GetValue<bool>(jPath);
+        }
+
+        public bool Enable { get; }
+    }
+}

--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Configurations/IElementCacheConfiguration.cs
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Configurations/IElementCacheConfiguration.cs
@@ -8,6 +8,6 @@
         /// <summary>
         /// Is element caching allowed or not.
         /// </summary>
-        bool Enable { get; }
+        bool IsEnabled { get; }
     }
 }

--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Configurations/IElementCacheConfiguration.cs
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Configurations/IElementCacheConfiguration.cs
@@ -1,0 +1,13 @@
+﻿namespace Aquality.Selenium.Core.Configurations
+{
+    /// <summary>
+    /// Represents element's cache configuration.
+    /// </summary>
+    public interface IElementCacheConfiguration
+    {
+        /// <summary>
+        /// Is element caching allowed or not.
+        /// </summary>
+        bool Enable { get; }
+    }
+}

--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/CachedElementStateProvider.cs
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/CachedElementStateProvider.cs
@@ -21,8 +21,11 @@ namespace Aquality.Selenium.Core.Elements
             this.locator = locator;
         }
 
+        protected virtual IList<Type> ExceptionsHandledByDefault => new List<Type> { typeof(StaleElementReferenceException) };
+
         protected virtual bool TryInvokeFunction(Func<IWebElement, bool> func, IList<Type> exceptionsToHandle = null)
         {
+            var handledExceptions = exceptionsToHandle ?? ExceptionsHandledByDefault;
             try
             {
                 return func(elementCacheHandler.GetElement(TimeSpan.Zero));

--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/CachedElementStateProvider.cs
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/CachedElementStateProvider.cs
@@ -32,7 +32,7 @@ namespace Aquality.Selenium.Core.Elements
             }
             catch (Exception e)
             {
-                if (exceptionsToHandle != null && exceptionsToHandle.Any(type => type.IsAssignableFrom(e.GetType())))
+                if (handledExceptions.Any(type => type.IsAssignableFrom(e.GetType())))
                 {
                     return false;
                 }

--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/CachedElementStateProvider.cs
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/CachedElementStateProvider.cs
@@ -58,35 +58,35 @@ namespace Aquality.Selenium.Core.Elements
 
         public virtual bool WaitForDisplayed(TimeSpan? timeout = null)
         {
-            return WaitForConditionWithLogging(() => TryInvokeFunction(element => element.Displayed), "displayed", timeout);
+            return WaitForCondition(() => TryInvokeFunction(element => element.Displayed), "displayed", timeout);
         }
 
         public virtual bool WaitForEnabled(TimeSpan? timeout = null)
         {
-            return WaitForConditionWithLogging(() => IsEnabled, "enabled", timeout);
+            return WaitForCondition(() => IsEnabled, "enabled", timeout);
         }
 
         public virtual bool WaitForExist(TimeSpan? timeout = null)
         {
-            return WaitForConditionWithLogging(() => TryInvokeFunction(element => true), "exist", timeout);
+            return WaitForCondition(() => TryInvokeFunction(element => true), "exist", timeout);
         }
 
         public virtual bool WaitForNotDisplayed(TimeSpan? timeout = null)
         {
-            return WaitForConditionWithLogging(() => !IsDisplayed, "invisible or absent", timeout);
+            return WaitForCondition(() => !IsDisplayed, "invisible or absent", timeout);
         }
 
         public virtual bool WaitForNotEnabled(TimeSpan? timeout = null)
         {
-            return WaitForConditionWithLogging(() => !IsEnabled, "disabled", timeout);
+            return WaitForCondition(() => !IsEnabled, "disabled", timeout);
         }
 
         public virtual bool WaitForNotExist(TimeSpan? timeout = null)
         {
-            return WaitForConditionWithLogging(() => !IsExist, "absent", timeout);
+            return WaitForCondition(() => !IsExist, "absent", timeout);
         }
 
-        protected virtual bool WaitForConditionWithLogging(Func<bool> condition, string conditionName, TimeSpan? timeout)
+        protected virtual bool WaitForCondition(Func<bool> condition, string conditionName, TimeSpan? timeout)
         {
             var result = conditionalWait.WaitFor(condition, timeout);
             if (!result)

--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/CachedElementStateProvider.cs
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/CachedElementStateProvider.cs
@@ -1,0 +1,98 @@
+﻿using Aquality.Selenium.Core.Elements.Interfaces;
+using Aquality.Selenium.Core.Logging;
+using Aquality.Selenium.Core.Waitings;
+using OpenQA.Selenium;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Aquality.Selenium.Core.Elements
+{
+    public class CachedElementStateProvider : IElementStateProvider
+    {
+        private readonly IElementCacheHandler elementCacheHandler;
+        private readonly ConditionalWait conditionalWait;
+        private readonly By locator;
+
+        public CachedElementStateProvider(By locator, ConditionalWait conditionalWait, IElementCacheHandler elementCacheHandler)
+        {
+            this.elementCacheHandler = elementCacheHandler;
+            this.conditionalWait = conditionalWait;
+            this.locator = locator;
+        }
+
+        protected virtual bool TryInvokeFunction(Func<IWebElement, bool> func, IList<Type> exceptionsToHandle = null)
+        {
+            try
+            {
+                return func(elementCacheHandler.GetElement(TimeSpan.Zero));
+            }
+            catch (Exception e)
+            {
+                if (exceptionsToHandle != null && exceptionsToHandle.Any(type => type.IsAssignableFrom(e.GetType())))
+                {
+                    return false;
+                }
+                throw;
+            }
+        }
+
+        public virtual bool IsDisplayed => !elementCacheHandler.IsStale 
+            && TryInvokeFunction(element => element.Displayed, new List<Type> { typeof(StaleElementReferenceException), typeof(NoSuchElementException) });
+
+        public virtual bool IsExist => !elementCacheHandler.IsStale
+            && TryInvokeFunction(element => true, new List<Type> { typeof(NoSuchElementException) });
+
+        public virtual bool IsClickable => TryInvokeFunction(element => element.Displayed && element.Enabled);
+
+        public virtual bool IsEnabled => TryInvokeFunction(element => element.Enabled);
+
+        public virtual void WaitForClickable(TimeSpan? timeout = null)
+        {
+            var errorMessage = $"Element {locator} has not become clickable after timeout.";
+            conditionalWait.WaitForTrue(() => IsClickable, timeout, message: errorMessage);
+        }
+
+        public virtual bool WaitForDisplayed(TimeSpan? timeout = null)
+        {
+            return WaitForConditionWithLogging(() => TryInvokeFunction(element => element.Displayed), "displayed", timeout);
+        }
+
+        public virtual bool WaitForEnabled(TimeSpan? timeout = null)
+        {
+            return WaitForConditionWithLogging(() => IsEnabled, "enabled", timeout);
+        }
+
+        public virtual bool WaitForExist(TimeSpan? timeout = null)
+        {
+            return WaitForConditionWithLogging(() => TryInvokeFunction(element => true), "exist", timeout);
+        }
+
+        public virtual bool WaitForNotDisplayed(TimeSpan? timeout = null)
+        {
+            return WaitForConditionWithLogging(() => !IsDisplayed, "invisible or absent", timeout);
+        }
+
+        public virtual bool WaitForNotEnabled(TimeSpan? timeout = null)
+        {
+            return WaitForConditionWithLogging(() => !IsEnabled, "disabled", timeout);
+        }
+
+        public virtual bool WaitForNotExist(TimeSpan? timeout = null)
+        {
+            return WaitForConditionWithLogging(() => !IsExist, "absent", timeout);
+        }
+
+        protected virtual bool WaitForConditionWithLogging(Func<bool> condition, string conditionName, TimeSpan? timeout)
+        {
+            var result = conditionalWait.WaitFor(condition, timeout);
+            if (!result)
+            {
+                var timeoutString = timeout == null ? string.Empty : $"of {timeout.Value.TotalSeconds} seconds";
+                Logger.Instance.Warn($"Element {locator} has not become {conditionName} after timeout {timeoutString}");
+            }
+
+            return result;
+        }
+    }
+}

--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/Element.cs
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/Element.cs
@@ -30,7 +30,7 @@ namespace Aquality.Selenium.Core.Elements
 
         public string Name { get; }
 
-        public virtual IElementStateProvider State => CacheConfiguration.Enable 
+        public virtual IElementStateProvider State => CacheConfiguration.IsEnabled 
             ? (IElementStateProvider) new CachedElementStateProvider(Locator, ConditionalWait, Cache)
             : new ElementStateProvider(Locator, ConditionalWait, Finder);
 
@@ -86,7 +86,7 @@ namespace Aquality.Selenium.Core.Elements
         {
             try
             {
-                return CacheConfiguration.Enable 
+                return CacheConfiguration.IsEnabled 
                     ? Cache.GetElement(timeout)
                     : (RemoteWebElement) Finder.FindElement(Locator, elementState, timeout);
             }

--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/ElementCacheHandler.cs
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/ElementCacheHandler.cs
@@ -33,7 +33,7 @@ namespace Aquality.Selenium.Core.Elements
                 try
                 {
                     var isDisplayed = remoteElement.Displayed;
-                    // no refresh needed if the property is available;
+                    // no refresh needed if the property is available
                     return false;
                 }
                 catch

--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/ElementCacheHandler.cs
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/ElementCacheHandler.cs
@@ -1,0 +1,57 @@
+﻿using Aquality.Selenium.Core.Elements.Interfaces;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Remote;
+using System;
+
+namespace Aquality.Selenium.Core.Elements
+{
+    public class ElementCacheHandler : IElementCacheHandler
+    {
+        private readonly By locator;
+        private readonly ElementState state;
+        private readonly IElementFinder elementFinder;
+
+        private RemoteWebElement remoteElement;
+
+        public ElementCacheHandler(By locator, ElementState state, IElementFinder finder)
+        {
+            this.locator = locator;
+            this.state = state;
+            elementFinder = finder;
+        }
+
+        public bool IsStale => remoteElement != null && IsRefreshNeeded;
+
+        public bool IsRefreshNeeded
+        {
+            get
+            {
+                if (remoteElement == null)
+                {
+                    return true;
+                }
+                try
+                {
+                    var isDisplayed = remoteElement.Displayed;
+                    // no refresh needed if the property is available;
+                    return false;
+                }
+                catch
+                {
+                    return true;
+                }
+            }
+        }
+
+        public RemoteWebElement GetElement(TimeSpan? timeout = null)
+        {
+
+            if (IsRefreshNeeded)
+            {
+                remoteElement = (RemoteWebElement)elementFinder.FindElement(locator, state, timeout);
+            }
+
+            return remoteElement;
+        }
+    }
+}

--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/Interfaces/IElementCacheHandler.cs
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/Interfaces/IElementCacheHandler.cs
@@ -1,0 +1,28 @@
+﻿using OpenQA.Selenium.Remote;
+using System;
+
+namespace Aquality.Selenium.Core.Elements.Interfaces
+{
+    /// <summary>
+    /// Allows to use cached element.
+    /// </summary>
+    public interface IElementCacheHandler
+    {
+        /// <summary>
+        /// Determines is the cached element refresh needed.
+        /// </summary>
+        bool IsRefreshNeeded { get; }
+
+        /// <summary>
+        /// Determines is the element stale.
+        /// </summary>
+        bool IsStale { get; }
+
+        /// <summary>
+        /// Allows to get cached element.
+        /// </summary>
+        /// <param name="timeout">Timeout used to retrive the element when <see cref="IsRefreshNeeded"/> is true.</param>
+        /// <returns>Cached element.</returns>
+        RemoteWebElement GetElement(TimeSpan? timeout = null);
+    }
+}

--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Resources/settings.json
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Resources/settings.json
@@ -11,5 +11,8 @@
   },
   "logger": {
     "language": "en"
+  },
+  "elementCache": {
+    "enable": false
   }
 }

--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Resources/settings.json
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Resources/settings.json
@@ -13,6 +13,6 @@
     "language": "en"
   },
   "elementCache": {
-    "enable": false
+    "isEnabled": false
   }
 }

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/AqualityServices.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/AqualityServices.cs
@@ -1,6 +1,5 @@
 ﻿using Aquality.Selenium.Core.Applications;
 using Aquality.Selenium.Core.Configurations;
-using Aquality.Selenium.Core.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using WebDriverManager;
@@ -22,7 +21,7 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
         {
             lock (downloadDriverLock)
             {
-                var version = EnvironmentConfiguration.GetVariable("webdriverversion") ?? "Latest";
+                var version = "Latest";
                 new DriverManager().SetUpDriver(new ChromeConfig(), version: version);
             }
 

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/CachedElementTests.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/CachedElementTests.cs
@@ -13,7 +13,7 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
     {
         private static readonly By RemoveButtonLoc = By.XPath("//button[.='Remove']");
         private static readonly By ContentLoc = By.Id("checkbox");
-        private static readonly Uri DynamicContentUrl = new Uri("http://the-internet.herokuapp.com/dynamic_controls");
+        private static readonly Uri DynamicContentUrl = new Uri($"{TestSite}/dynamic_controls");
         private const string ElementCacheVariableName = "elementCache.isEnabled"; 
         
         private static readonly Func<IElementStateProvider, bool>[] StateFunctionsFalseWhenElementStale
@@ -52,7 +52,6 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
             AqualityServices.Application.Driver.Navigate().Refresh();
             var newToString = example.GetElement().ToString();
             Assert.AreNotEqual(exToString, newToString);
-
         }
         
         [Test]

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/CachedElementTests.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/CachedElementTests.cs
@@ -14,7 +14,7 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
         private static readonly By RemoveButtonLoc = By.XPath("//button[.='Remove']");
         private static readonly By ContentLoc = By.Id("checkbox");
         private static readonly Uri DynamicContentUrl = new Uri("http://the-internet.herokuapp.com/dynamic_controls");
-        private const string ElementCacheVariableName = "elementCache.enable"; 
+        private const string ElementCacheVariableName = "elementCache.isEnabled"; 
         
         private static readonly Func<IElementStateProvider, bool>[] StateFunctionsFalseWhenElementStale
             = new Func<IElementStateProvider, bool>[]

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/CachedElementTests.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/CachedElementTests.cs
@@ -1,0 +1,92 @@
+﻿using Aquality.Selenium.Core.Elements;
+using Aquality.Selenium.Core.Elements.Interfaces;
+using Aquality.Selenium.Core.Tests.Applications.WindowsApp.Elements;
+using Aquality.Selenium.Core.Waitings;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using OpenQA.Selenium;
+using System;
+
+namespace Aquality.Selenium.Core.Tests.Applications.Browser
+{
+    public class CachedElementTests : TestWithBrowser
+    {
+        private static readonly By RemoveButtonLoc = By.XPath("//button[.='Remove']");
+        private static readonly By ContentLoc = By.Id("checkbox");
+        private static readonly Uri DynamicContentUrl = new Uri("http://the-internet.herokuapp.com/dynamic_controls");
+        private const string ElementCacheVariableName = "elementCache.enable"; 
+        
+        private static readonly Func<IElementStateProvider, bool>[] StateFunctionsFalseWhenElementStale
+            = new Func<IElementStateProvider, bool>[]
+            {
+                state => state.IsDisplayed,
+                state => state.IsExist,            
+                state => !state.WaitForNotDisplayed(TimeSpan.Zero),
+                state => !state.WaitForNotExist(TimeSpan.Zero),
+            };
+
+        private static readonly Func<IElementStateProvider, bool>[] StateFunctionsTrueWhenElementStaleWhichRetriveElement
+            = new Func<IElementStateProvider, bool>[]
+            {
+                state => state.IsEnabled,
+                state => state.IsClickable,
+                state => state.WaitForDisplayed(TimeSpan.Zero),
+                state => state.WaitForExist(TimeSpan.Zero),
+                state => state.WaitForEnabled(TimeSpan.Zero),
+                state => !state.WaitForNotEnabled(TimeSpan.Zero),
+            };
+
+        [SetUp]
+        public new void SetUp()
+        {
+            Environment.SetEnvironmentVariable(ElementCacheVariableName, true.ToString());
+            AqualityServices.Application.Driver.Navigate().GoToUrl(DynamicContentUrl);
+        }
+
+        [Test]
+        public void Should_RefreshElement_WhenItIsStale()
+        {
+            var example = new Label(ContentLoc, "Example", ElementState.Displayed);
+            example.GetElement();
+            var exToString = example.GetElement().ToString();
+            AqualityServices.Application.Driver.Navigate().Refresh();
+            var newToString = example.GetElement().ToString();
+            Assert.AreNotEqual(exToString, newToString);
+
+        }
+        
+        [Test]
+        public void Should_ReturnCorrectState_False_WhenWindowIsRefreshed([ValueSource(nameof(StateFunctionsFalseWhenElementStale))] Func<IElementStateProvider, bool> stateCondition)
+        {
+            AssertStateConditionAfterRefresh(stateCondition, expectedValue: false);
+        }
+
+        [Test]
+        public void Should_ReturnCorrectState_True_WhenWindowIsRefreshed([ValueSource(nameof(StateFunctionsTrueWhenElementStaleWhichRetriveElement))] Func<IElementStateProvider, bool> stateCondition)
+        {
+            AssertStateConditionAfterRefresh(stateCondition, expectedValue: true);
+        }
+
+        private void AssertStateConditionAfterRefresh(Func<IElementStateProvider, bool> stateCondition, bool expectedValue)
+        {
+            var testElement = new Label(ContentLoc, "Example", ElementState.ExistsInAnyState);
+            testElement.State.WaitForClickable();
+            new Label(RemoveButtonLoc, "Remove", ElementState.Displayed).Click();
+            AqualityServices.ServiceProvider.GetRequiredService<ConditionalWait>().WaitFor(driver =>
+            {
+                return testElement.Cache.IsStale;
+            }, message: "Element should be stale when it disappeared.");
+            AqualityServices.Application.Driver.Navigate().Refresh();
+            Assert.IsTrue(testElement.Cache.IsStale, "Element should remain stale after the page refresh.");
+            Assert.AreEqual(expectedValue, stateCondition(testElement.State), 
+                "Element state condition is not expected after refreshing the window");            
+        }
+
+        [TearDown]
+        public new void CleanUp()
+        {
+            Environment.SetEnvironmentVariable(ElementCacheVariableName, null);
+            base.CleanUp();
+        }
+    }
+}

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/ChromeApplication.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/ChromeApplication.cs
@@ -1,7 +1,10 @@
 ﻿using Aquality.Selenium.Core.Applications;
 using Aquality.Selenium.Core.Configurations;
+using Aquality.Selenium.Core.Waitings;
+using Microsoft.Extensions.DependencyInjection;
 using OpenQA.Selenium.Chrome;
 using OpenQA.Selenium.Remote;
+using OpenQA.Selenium.Support.Extensions;
 using System;
 
 namespace Aquality.Selenium.Core.Tests.Applications.Browser
@@ -28,6 +31,13 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
                 Driver.Manage().Timeouts().ImplicitWait = timeout;
                 implicitWait = timeout;
             }
+        }
+
+        public void WaitForPageToLoad()
+        {
+            AqualityServices.ServiceProvider.GetRequiredService<ConditionalWait>().WaitForTrue(
+                () => AqualityServices.Application.Driver.ExecuteJavaScript<bool>(
+                    "return document['readyState'] ? 'complete' === document.readyState : true;"));
         }
 
         public void Quit()

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/ChromeApplication.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/ChromeApplication.cs
@@ -1,10 +1,7 @@
 ﻿using Aquality.Selenium.Core.Applications;
 using Aquality.Selenium.Core.Configurations;
-using Aquality.Selenium.Core.Waitings;
-using Microsoft.Extensions.DependencyInjection;
 using OpenQA.Selenium.Chrome;
 using OpenQA.Selenium.Remote;
-using OpenQA.Selenium.Support.Extensions;
 using System;
 
 namespace Aquality.Selenium.Core.Tests.Applications.Browser

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/ChromeApplication.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/ChromeApplication.cs
@@ -33,13 +33,6 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
             }
         }
 
-        public void WaitForPageToLoad()
-        {
-            AqualityServices.ServiceProvider.GetRequiredService<ConditionalWait>().WaitForTrue(
-                () => AqualityServices.Application.Driver.ExecuteJavaScript<bool>(
-                    "return document['readyState'] ? 'complete' === document.readyState : true;"));
-        }
-
         public void Quit()
         {
             Driver?.Quit();

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/Elements/Label.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/Elements/Label.cs
@@ -1,4 +1,5 @@
 ﻿using Aquality.Selenium.Core.Elements;
+using Aquality.Selenium.Core.Elements.Interfaces;
 using Aquality.Selenium.Core.Tests.Applications.Browser;
 using OpenQA.Selenium;
 
@@ -11,5 +12,7 @@ namespace Aquality.Selenium.Core.Tests.Applications.WindowsApp.Elements
         }
 
         protected override string ElementType { get; } = "Label";
+
+        public new IElementCacheHandler Cache => base.Cache;
     }
 }

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/Elements/WebElement.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/Elements/WebElement.cs
@@ -1,4 +1,5 @@
 ﻿using Aquality.Selenium.Core.Applications;
+using Aquality.Selenium.Core.Configurations;
 using Aquality.Selenium.Core.Elements;
 using Aquality.Selenium.Core.Elements.Interfaces;
 using Aquality.Selenium.Core.Localization;
@@ -18,6 +19,8 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
         protected override ElementActionRetrier ActionRetrier => AqualityServices.ServiceProvider.GetRequiredService<ElementActionRetrier>();
 
         protected override IApplication Application => AqualityServices.Application;
+
+        protected override IElementCacheConfiguration CacheConfiguration => AqualityServices.ServiceProvider.GetRequiredService<IElementCacheConfiguration>();
 
         protected override ConditionalWait ConditionalWait => AqualityServices.ServiceProvider.GetRequiredService<ConditionalWait>();
 

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/FindElementsTests.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/FindElementsTests.cs
@@ -14,7 +14,7 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
         private static readonly By DisplayedElementsLoc = By.XPath("//img[@alt='User Avatar']");
         private static readonly By NotExistElementLoc = By.XPath("//div[@class='testtest']");
         private static readonly By ContentLoc = By.XPath("//div[contains(@class,'example')]");
-        private static readonly Uri HoversURL = new Uri("http://the-internet.herokuapp.com/hovers");
+        private static readonly Uri HoversURL = new Uri($"{TestSite}/hovers");
         private IElementFactory elementFactory;
 
         [SetUp]

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/TestWithBrowser.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/TestWithBrowser.cs
@@ -8,6 +8,8 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
     [Parallelizable(ParallelScope.All)]
     public abstract class TestWithBrowser
     {
+        protected static string TestSite => "http://the-internet.herokuapp.com";
+
         protected ServiceProvider ServiceProvider { get; private set; }
 
         [SetUp]

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/WindowsApp/CachedElementTests.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/WindowsApp/CachedElementTests.cs
@@ -1,0 +1,116 @@
+﻿using Aquality.Selenium.Core.Elements.Interfaces;
+using Aquality.Selenium.Core.Tests.Applications.WindowsApp.Elements;
+using Aquality.Selenium.Core.Tests.Applications.WindowsApp.Locators;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using System;
+
+namespace Aquality.Selenium.Core.Tests.Applications.WindowsApp
+{
+    public class CachedElementTests : TestWithApplication
+    {
+        private const string ElementCacheVariableName = "elementCache.enable"; 
+        
+        private IElementFactory Factory => AqualityServices.ServiceProvider.GetRequiredService<IElementFactory>();
+
+        private static readonly Func<IElementStateProvider, bool>[] StateFunctionsFalseWhenElementStale
+            = new Func<IElementStateProvider, bool>[]
+            {
+                state => state.IsDisplayed,
+                state => state.IsExist,                
+                state => !state.WaitForNotDisplayed(TimeSpan.Zero),
+                state => !state.WaitForNotExist(TimeSpan.Zero),
+            };
+
+        private static readonly Func<IElementStateProvider, bool>[] StateFunctionsTrueWhenElementStaleWhichRetriveSession
+            = new Func<IElementStateProvider, bool>[]
+            {
+                state => state.IsEnabled,
+                state => state.IsClickable,
+                state => state.WaitForDisplayed(TimeSpan.Zero),
+                state => state.WaitForExist(TimeSpan.Zero),
+                state => state.WaitForEnabled(TimeSpan.Zero),
+                state => !state.WaitForNotEnabled(TimeSpan.Zero),
+            };
+
+        [SetUp]
+        public void SetUp()
+        {
+            Environment.SetEnvironmentVariable(ElementCacheVariableName, true.ToString());
+        }
+
+        [Test]
+        public void Should_WorkWithCalculator_WithCachedElement()
+        {
+            var oneButton = Factory.GetButton(CalculatorWindow.OneButton, "1");            
+            oneButton.Click();
+            Factory.GetButton(CalculatorWindow.PlusButton, "+").Click();
+            oneButton.Click();
+            Factory.GetButton(CalculatorWindow.EqualsButton, "=").Click();
+            var result = Factory.GetButton(CalculatorWindow.ResultsLabel, "Results bar").Text;
+            StringAssert.Contains("2", result);
+        }
+
+        [Test]
+        public void Should_ReturnSameElement_AfterInteraction()
+        {
+            const string errorMessage = "Element is not the same after the interaction";
+            var oneButton = Factory.GetButton(CalculatorWindow.OneButton, "1");
+            var initialElement = oneButton.GetElement();
+            oneButton.Click();
+            var resultElement = oneButton.GetElement();
+            Assert.AreEqual(initialElement, resultElement, errorMessage);
+        }
+
+        [Test]
+        public void Should_ReturnSameElement_AfterGetState()
+        {
+            const string errorMessage = "Element is not the same after getting state";
+            var oneButton = Factory.GetButton(CalculatorWindow.OneButton, "1");
+            var initialElement = oneButton.GetElement();
+            oneButton.State.WaitForClickable();
+            var resultElement = oneButton.GetElement();
+            Assert.AreEqual(initialElement, resultElement, errorMessage);
+        }
+
+        [Test]
+        public void Should_ReturnNewElement_WhenWindowIsReopened()
+        {
+            const string errorMessage = "Element is still the same after reopening the window";
+            var oneButton = Factory.GetButton(CalculatorWindow.OneButton, "1");
+            var initialElement = oneButton.GetElement().ToString();
+            AqualityServices.Application.Driver.Quit();
+            oneButton.State.WaitForClickable();
+            var resultElement = oneButton.GetElement().ToString();
+            Assert.AreNotEqual(initialElement, resultElement, errorMessage);
+        }
+
+        [Test]
+        public void Should_ReturnCorrectState_WhenWindowIsClosed([ValueSource(nameof(StateFunctionsFalseWhenElementStale))] Func<IElementStateProvider, bool> stateCondition)
+        {
+            AssertStateConditionAfterQuit(stateCondition, expectedValue: false, shouldAppRestart: false);
+        }
+
+        [Test]
+        public void Should_ReturnCorrectState_AndReopenApplication_WhenWindowIsClosed([ValueSource(nameof(StateFunctionsTrueWhenElementStaleWhichRetriveSession))] Func<IElementStateProvider, bool> stateCondition)
+        {
+            AssertStateConditionAfterQuit(stateCondition, expectedValue: true, shouldAppRestart: true);
+        }
+
+        private void AssertStateConditionAfterQuit(Func<IElementStateProvider, bool> stateCondition, bool expectedValue, bool shouldAppRestart)
+        {
+            var oneButton = Factory.GetButton(CalculatorWindow.OneButton, "1");
+            oneButton.GetElement();
+            AqualityServices.Application.Driver.Quit();
+            Assert.AreEqual(expectedValue, stateCondition(oneButton.State), "Element state condition is not expected after closing the window");
+            Assert.AreEqual(shouldAppRestart, AqualityServices.IsApplicationStarted, $"Window was {(shouldAppRestart ? "not " : string.Empty)}reopened when retrived the element state.");
+        }
+
+        [TearDown]
+        public new void CleanUp()
+        {
+            Environment.SetEnvironmentVariable(ElementCacheVariableName, null);
+            base.CleanUp();
+        }
+    }
+}

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/WindowsApp/CachedElementTests.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/WindowsApp/CachedElementTests.cs
@@ -9,7 +9,7 @@ namespace Aquality.Selenium.Core.Tests.Applications.WindowsApp
 {
     public class CachedElementTests : TestWithApplication
     {
-        private const string ElementCacheVariableName = "elementCache.enable"; 
+        private const string ElementCacheVariableName = "elementCache.isEnabled"; 
         
         private IElementFactory Factory => AqualityServices.ServiceProvider.GetRequiredService<IElementFactory>();
 

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/WindowsApp/Elements/WindowElement.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/WindowsApp/Elements/WindowElement.cs
@@ -1,4 +1,5 @@
 ﻿using Aquality.Selenium.Core.Applications;
+using Aquality.Selenium.Core.Configurations;
 using Aquality.Selenium.Core.Elements;
 using Aquality.Selenium.Core.Elements.Interfaces;
 using Aquality.Selenium.Core.Localization;
@@ -18,6 +19,8 @@ namespace Aquality.Selenium.Core.Tests.Applications.WindowsApp.Elements
         protected override ElementActionRetrier ActionRetrier => AqualityServices.ServiceProvider.GetRequiredService<ElementActionRetrier>();
 
         protected override IApplication Application => AqualityServices.Application;
+
+        protected override IElementCacheConfiguration CacheConfiguration => AqualityServices.ServiceProvider.GetRequiredService<IElementCacheConfiguration>();
 
         protected override ConditionalWait ConditionalWait => AqualityServices.ServiceProvider.GetRequiredService<ConditionalWait>();
 

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Configurations/EnvConfigurationTests.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Configurations/EnvConfigurationTests.cs
@@ -79,15 +79,23 @@ namespace Aquality.Selenium.Core.Tests.Configurations
         [Test]
         public void Should_ReturnFalse_InElementCacheEnable_WhenElementCacheIsAbsent()
         {
-            Assert.IsFalse(ServiceProvider.GetRequiredService<IElementCacheConfiguration>().Enable,
+            Assert.IsFalse(ServiceProvider.GetRequiredService<IElementCacheConfiguration>().IsEnabled,
                 nameof(Should_ReturnFalse_InElementCacheEnable_WhenElementCacheIsAbsent));
+        }
+
+        [Test]
+        public void Should_ReturnTrue_InElementCacheEnable_WhenElementCacheIsDisabled()
+        {
+            Environment.SetEnvironmentVariable("elementCache.isEnabled", "true");
+            Assert.IsTrue(ServiceProvider.GetRequiredService<IElementCacheConfiguration>().IsEnabled,
+                nameof(Should_ReturnTrue_InElementCacheEnable_WhenElementCacheIsDisabled));
         }
 
         [Test]
         public void Should_ReturnFalse_InElementCacheEnable_WhenElementCacheIsDisabled()
         {
-            Environment.SetEnvironmentVariable(".elementCache.enable", "false");
-            Assert.IsFalse(ServiceProvider.GetRequiredService<IElementCacheConfiguration>().Enable,
+            Environment.SetEnvironmentVariable("elementCache.isEnabled", "false");
+            Assert.IsFalse(ServiceProvider.GetRequiredService<IElementCacheConfiguration>().IsEnabled,
                 nameof(Should_ReturnFalse_InElementCacheEnable_WhenElementCacheIsDisabled));
         }
     }

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Configurations/EnvConfigurationTests.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Configurations/EnvConfigurationTests.cs
@@ -75,5 +75,20 @@ namespace Aquality.Selenium.Core.Tests.Configurations
             var config = ServiceProvider.GetService<ILoggerConfiguration>();
             Assert.AreEqual(testValue, config.Language, "Logger language value should be overridden with env variable");
         }
+
+        [Test]
+        public void Should_ReturnFalse_InElementCacheEnable_WhenElementCacheIsAbsent()
+        {
+            Assert.IsFalse(ServiceProvider.GetRequiredService<IElementCacheConfiguration>().Enable,
+                nameof(Should_ReturnFalse_InElementCacheEnable_WhenElementCacheIsAbsent));
+        }
+
+        [Test]
+        public void Should_ReturnFalse_InElementCacheEnable_WhenElementCacheIsDisabled()
+        {
+            Environment.SetEnvironmentVariable(".elementCache.enable", "false");
+            Assert.IsFalse(ServiceProvider.GetRequiredService<IElementCacheConfiguration>().Enable,
+                nameof(Should_ReturnFalse_InElementCacheEnable_WhenElementCacheIsDisabled));
+        }
     }
 }


### PR DESCRIPTION
Allow to cache the found element. Aim is to reduce times of element search.
Add ElementCacheConfiguration, ElementCacheHandler and CachedElementStateProvider.
Add some tests for the new functionality.
Closes #47 