### PR TITLE
Implement FindChildElements for IElement +semver: feature

### DIFF
--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Aquality.Selenium.Core.xml
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Aquality.Selenium.Core.xml
@@ -366,11 +366,24 @@
             <exception cref="T:System.InvalidOperationException">Thrown when the supplier is null, and no constructor with required arguments was found.</exception>
             <returns>Instance of child element</returns>
         </member>
+        <member name="M:Aquality.Selenium.Core.Elements.Interfaces.IElementFactory.FindChildElements``1(Aquality.Selenium.Core.Elements.Interfaces.IElement,OpenQA.Selenium.By,System.String,Aquality.Selenium.Core.Elements.ElementSupplier{``0},Aquality.Selenium.Core.Elements.ElementsCount,Aquality.Selenium.Core.Elements.ElementState)">
+            <summary>
+            Finds list of child elements by their locator relative to parent element.
+            </summary>
+            <typeparam name="T">Type of child elements that has to implement IElement.</typeparam>
+            <param name="parentElement">Parent element.</param>
+            <param name="childLocator">Locator of child elements relative to their parent.</param>
+            <param name="supplier">Delegate that defines constructor of element in case of custom element type.</param>
+            <param name="state">Child elements state.</param>
+            <param name="name">Child elements name.</param>
+            <exception cref="T:System.InvalidOperationException">Thrown when the supplier is null, and no constructor with required arguments was found.</exception>
+            <returns>List of child elements.</returns>
+        </member>
         <member name="M:Aquality.Selenium.Core.Elements.Interfaces.IElementFactory.FindElements``1(OpenQA.Selenium.By,System.String,Aquality.Selenium.Core.Elements.ElementSupplier{``0},Aquality.Selenium.Core.Elements.ElementsCount,Aquality.Selenium.Core.Elements.ElementState)">
             <summary>
             Finds list of elements by base locator.
             </summary>
-            <typeparam name="T">Type of elements that have to implement IElement.</typeparam>
+            <typeparam name="T">Type of elements that has to implement IElement.</typeparam>
             <param name="locator">Base elements locator.</param>
             <param name="supplier">Delegate that defines constructor of element in case of custom elements.</param>
             <param name="expectedCount">Expected number of elements that have to be found (zero, more then zero, any).</param>
@@ -525,6 +538,17 @@
             <param name="state">Child element state.</param>
             <returns>Instance of child element.</returns>
         </member>
+        <member name="M:Aquality.Selenium.Core.Elements.Interfaces.IParent.FindChildElements``1(OpenQA.Selenium.By,System.String,Aquality.Selenium.Core.Elements.ElementSupplier{``0},Aquality.Selenium.Core.Elements.ElementsCount,Aquality.Selenium.Core.Elements.ElementState)">
+            <summary>
+            Finds child elements of current element by its locator.
+            </summary>
+            <typeparam name="T">Type of child elements that has to implement IElement.</typeparam>
+            <param name="childLocator">Locator of child elements relative to their parent.</param>
+            <param name="name">Child elements name.</param>
+            <param name="supplier">Delegate that defines constructor of child element in case of custom element type.</param>
+            <param name="state">Child elements state.</param>
+            <returns>List of child elements.</returns>
+        </member>
         <member name="T:Aquality.Selenium.Core.Elements.RelativeElementFinder">
             <summary>
             Implementation of <see cref="T:Aquality.Selenium.Core.Elements.Interfaces.IElementFinder"/> for a relative <see cref="T:OpenQA.Selenium.ISearchContext"/> supplier
@@ -650,45 +674,69 @@
             <param name="message">Message</param>
             <param name="exception">Exception</param>
         </member>
+        <member name="M:Aquality.Selenium.Core.Utilities.ActionRetrier.#ctor(Aquality.Selenium.Core.Configurations.IRetryConfiguration)">
+            <summary>
+            Instantiates the class using retry configuration.
+            </summary>
+            <param name="retryConfiguration">Retry configuration.</param>
+        </member>
+        <member name="M:Aquality.Selenium.Core.Utilities.ActionRetrier.DoWithRetry(System.Action,System.Collections.Generic.IEnumerable{System.Type})">
+            <summary>
+            Retries the action when one of the handledExceptions occures.
+            </summary>
+            <param name="action">Action to be applied.</param>
+            <param name="handledExceptions">Exceptions to be handled.</param>
+        </member>
+        <member name="M:Aquality.Selenium.Core.Utilities.ActionRetrier.DoWithRetry``1(System.Func{``0},System.Collections.Generic.IEnumerable{System.Type})">
+            <summary>
+            Retries the action when one of the handledExceptions occures.
+            </summary>
+            <typeparam name="T">Return type of function.</typeparam>
+            <param name="function">Function to be applied.</param>
+            <param name="handledExceptions">Exceptions to be handled.</param>
+            <returns>Result of the function.</returns>
+        </member>
+        <member name="M:Aquality.Selenium.Core.Utilities.ActionRetrier.IsExceptionHandled(System.Collections.Generic.IEnumerable{System.Type},System.Exception)">
+            <summary>
+            Decides should the occured exception be handled (ignored during the retry) or not.
+            </summary>
+            <param name="handledExceptions">Exceptions to be handled.</param>
+            <param name="exception">Exception to proceed.</param>
+            <returns>True if the exception should be ignored, false otherwise.</returns>
+        </member>
         <member name="T:Aquality.Selenium.Core.Utilities.ElementActionRetrier">
             <summary>
             Retries an action or function when <see cref="P:Aquality.Selenium.Core.Utilities.ElementActionRetrier.HandledExceptions"/> occures.
             </summary>
         </member>
-        <member name="M:Aquality.Selenium.Core.Utilities.ElementActionRetrier.#ctor(Aquality.Selenium.Core.Configurations.IRetryConfiguration,System.Collections.Generic.IList{System.Type})">
+        <member name="M:Aquality.Selenium.Core.Utilities.ElementActionRetrier.#ctor(Aquality.Selenium.Core.Configurations.IRetryConfiguration)">
             <summary>
             Instantiates the class using retry configuration.
             </summary>
             <param name="retryConfiguration">Retry configuration.</param>
-            <param name="handledExceptions">Exceptions to be handled. 
-            If set to null, <see cref="T:OpenQA.Selenium.StaleElementReferenceException"/> and <see cref="T:OpenQA.Selenium.InvalidElementStateException"/> will be handled.</param>
         </member>
         <member name="P:Aquality.Selenium.Core.Utilities.ElementActionRetrier.HandledExceptions">
             <summary>
             Exceptions to be ignored during action retrying.
             Set by the constructor parameter.
-            If were not passed to constructor, <see cref="T:OpenQA.Selenium.StaleElementReferenceException"/> and <see cref="T:OpenQA.Selenium.InvalidElementStateException"/> will be handled.
+            If were not passed to constructor, <see cref="T:OpenQA.Selenium.StaleElementReferenceException"/> 
+            and <see cref="T:OpenQA.Selenium.InvalidElementStateException"/> will be handled.
             </summary>
         </member>
-        <member name="M:Aquality.Selenium.Core.Utilities.ElementActionRetrier.IsExceptionHandled(System.Exception)">
-            <summary>
-            Decides should the occured exception be handled (ignored during the retry) or not.
-            </summary>
-            <param name="exception">Exception to proceed.</param>
-            <returns>True if the exception should be ignored, false otherwise.</returns>
-        </member>
-        <member name="M:Aquality.Selenium.Core.Utilities.ElementActionRetrier.DoWithRetry(System.Action)">
+        <member name="M:Aquality.Selenium.Core.Utilities.ElementActionRetrier.DoWithRetry(System.Action,System.Collections.Generic.IEnumerable{System.Type})">
             <summary>
             Retries the action when the handled exception <see cref="P:Aquality.Selenium.Core.Utilities.ElementActionRetrier.HandledExceptions"/> occures.
             </summary>
             <param name="action">Action to be applied.</param>
+            <param name="handledExceptions">Exceptions to be handled.</param>
         </member>
-        <member name="M:Aquality.Selenium.Core.Utilities.ElementActionRetrier.DoWithRetry``1(System.Func{``0})">
+        <member name="M:Aquality.Selenium.Core.Utilities.ElementActionRetrier.DoWithRetry``1(System.Func{``0},System.Collections.Generic.IEnumerable{System.Type})">
             <summary>
             Retries the function when <see cref="P:Aquality.Selenium.Core.Utilities.ElementActionRetrier.HandledExceptions"/> occures.
             </summary>
             <typeparam name="T">Return type of function.</typeparam>
             <param name="function">Function to be applied.</param>
+            <param name="handledExceptions">Exceptions to be handled.</param>
             <returns>Result of the function.</returns>
         </member>
         <member name="T:Aquality.Selenium.Core.Utilities.EnumExtensions">
@@ -762,30 +810,38 @@
             <param name="fileInfo">Required file info.</param>
             <returns>Text of the file.</returns>
         </member>
+        <member name="T:Aquality.Selenium.Core.Utilities.IActionRetrier">
+            <summary>
+            Retries an action or function when handledExceptions occurs.
+            </summary>
+        </member>
+        <member name="M:Aquality.Selenium.Core.Utilities.IActionRetrier.DoWithRetry(System.Action,System.Collections.Generic.IEnumerable{System.Type})">
+            <summary>
+            Retries the action when one of the handledExceptions occures.
+            </summary>
+            <param name="action">Action to be applied.</param>
+            <param name="handledExceptions">Exceptions to be handled.</param>
+        </member>
+        <member name="M:Aquality.Selenium.Core.Utilities.IActionRetrier.DoWithRetry``1(System.Func{``0},System.Collections.Generic.IEnumerable{System.Type})">
+            <summary>
+            Retries the action when one of the handledExceptions occures.
+            </summary>
+            <typeparam name="T">Return type of function.</typeparam>
+            <param name="function">Function to be applied.</param>
+            <param name="handledExceptions">Exceptions to be handled.</param>
+            <returns>Result of the function.</returns>
+        </member>
         <member name="T:Aquality.Selenium.Core.Utilities.IElementActionRetrier">
             <summary>
-            Retries an action or function when <see cref="P:Aquality.Selenium.Core.Utilities.IElementActionRetrier.HandledExceptions"/> occures.
+            Retries an action or function when one of <see cref="P:Aquality.Selenium.Core.Utilities.IElementActionRetrier.HandledExceptions"/> occures.
             </summary>
         </member>
         <member name="P:Aquality.Selenium.Core.Utilities.IElementActionRetrier.HandledExceptions">
             <summary>
             Exceptions to be ignored during action retrying.
-            By the default implementation, <see cref="T:OpenQA.Selenium.StaleElementReferenceException"/> and <see cref="T:OpenQA.Selenium.InvalidElementStateException"/> are handled.
+            By the default implementation, <see cref="T:OpenQA.Selenium.StaleElementReferenceException"/> 
+            and <see cref="T:OpenQA.Selenium.InvalidElementStateException"/> are handled.
             </summary>
-        </member>
-        <member name="M:Aquality.Selenium.Core.Utilities.IElementActionRetrier.DoWithRetry(System.Action)">
-            <summary>
-            Retries the action when the handled exception <see cref="P:Aquality.Selenium.Core.Utilities.IElementActionRetrier.HandledExceptions"/> occures.
-            </summary>
-            <param name="action">Action to be applied.</param>
-        </member>
-        <member name="M:Aquality.Selenium.Core.Utilities.IElementActionRetrier.DoWithRetry``1(System.Func{``0})">
-            <summary>
-            Retries the function when the handled exception <see cref="P:Aquality.Selenium.Core.Utilities.IElementActionRetrier.HandledExceptions"/> occures.
-            </summary>
-            <typeparam name="T">Return type of function.</typeparam>
-            <param name="function">Function to be applied.</param>
-            <returns>Result of the function.</returns>
         </member>
         <member name="T:Aquality.Selenium.Core.Utilities.JsonSettingsFile">
             <summary>

--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Aquality.Selenium.Core.xml
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Aquality.Selenium.Core.xml
@@ -225,6 +225,32 @@
             <param name="elementIndex">index of target element</param>
             <returns>target element's locator</returns>
         </member>
+        <member name="M:Aquality.Selenium.Core.Elements.ElementFactory.GenerateAbsoluteChildLocator(OpenQA.Selenium.By,OpenQA.Selenium.By)">
+            <summary>
+            Generates absolute child locator for target element.
+            </summary>
+            <param name="parentLocator">parent locator</param>
+            <param name="childLocator">child locator relative to parent</param>
+            <returns>absolute locator of the child</returns>
+        </member>
+        <member name="M:Aquality.Selenium.Core.Elements.ElementFactory.ExtractXPathFromLocator(OpenQA.Selenium.By)">
+            <summary>
+            Extracts XPath from passed locator.
+            Current implementation works only with ByXPath.class and ByTagName locator types,
+            but you can implement your own for the specific WebDriver type.
+            </summary>
+            <param name="locator">locator to get xpath from.</param>
+            <returns>extracted XPath.</returns>
+        </member>
+        <member name="M:Aquality.Selenium.Core.Elements.ElementFactory.IsLocatorSupportedForXPathExtraction(OpenQA.Selenium.By)">
+            <summary>
+            Defines is the locator can be transformed to xpath or not.
+            Current implementation works only with ByXPath.class and ByTagName locator types,
+            but you can implement your own for the specific WebDriver type.
+            </summary>
+            <param name="locator">locator to transform</param>
+            <returns>true if the locator can be transformed to xpath, false otherwise.</returns>
+        </member>
         <member name="M:Aquality.Selenium.Core.Elements.ElementFactory.ResolveSupplier``1(Aquality.Selenium.Core.Elements.ElementSupplier{``0})">
             <summary>
             Resolves element supplier or return itself if it is not null

--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Aquality.Selenium.Core.xml
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Aquality.Selenium.Core.xml
@@ -374,6 +374,7 @@
             <param name="parentElement">Parent element.</param>
             <param name="childLocator">Locator of child elements relative to their parent.</param>
             <param name="supplier">Delegate that defines constructor of element in case of custom element type.</param>
+            <param name="expectedCount">Expected number of elements that have to be found (zero, more then zero, any).</param>
             <param name="state">Child elements state.</param>
             <param name="name">Child elements name.</param>
             <exception cref="T:System.InvalidOperationException">Thrown when the supplier is null, and no constructor with required arguments was found.</exception>
@@ -546,6 +547,7 @@
             <param name="childLocator">Locator of child elements relative to their parent.</param>
             <param name="name">Child elements name.</param>
             <param name="supplier">Delegate that defines constructor of child element in case of custom element type.</param>
+            <param name="expectedCount">Expected number of elements that have to be found (zero, more then zero, any).</param>
             <param name="state">Child elements state.</param>
             <returns>List of child elements.</returns>
         </member>

--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/Element.cs
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/Element.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Aquality.Selenium.Core.Applications;
 using Aquality.Selenium.Core.Configurations;
 using Aquality.Selenium.Core.Elements.Interfaces;
@@ -74,6 +75,11 @@ namespace Aquality.Selenium.Core.Elements
         public T FindChildElement<T>(By childLocator, string name = null, ElementSupplier<T> supplier = null, ElementState state = ElementState.Displayed) where T : IElement
         {
             return Factory.FindChildElement(this, childLocator, name, supplier, state);
+        }
+
+        public IList<T> FindChildElements<T>(By childLocator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed) where T : IElement
+        {
+            return Factory.FindChildElements(this, childLocator, name, supplier, expectedCount, state);
         }
 
         public string GetAttribute(string attr)

--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/ElementFactory.cs
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/ElementFactory.cs
@@ -43,6 +43,11 @@ namespace Aquality.Selenium.Core.Elements
             return elementSupplier(new ByChained(parentElement.Locator, childLocator), name ?? $"Child element of {parentElement.Name}", state);
         }
 
+        public virtual IList<T> FindChildElements<T>(IElement parentElement, By childLocator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed) where T : IElement
+        {
+            return FindElements(new ByChained(parentElement.Locator, childLocator), name ?? $"Child element of {parentElement.Name}", supplier, expectedCount, state);
+        }
+
         public virtual IList<T> FindElements<T>(By locator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed) where T : IElement
         {
             var elementSupplier = ResolveSupplier(supplier);
@@ -88,8 +93,8 @@ namespace Aquality.Selenium.Core.Elements
         protected virtual By GenerateXpathLocator(By baseLocator, IWebElement webElement, int elementIndex)
         {
             var strBaseLocator = baseLocator.ToString();
-            var elementLocator = strBaseLocator.Contains(ByXpathIdentifier)
-                    ? $"({strBaseLocator.Split(':')[1].Trim()})[{elementIndex}]"
+            var elementLocator = strBaseLocator.StartsWith(ByXpathIdentifier)
+                    ? $"({strBaseLocator.Substring(strBaseLocator.IndexOf(':') + 1).Trim()})[{elementIndex}]"
                     : throw new NotSupportedException($"Multiple elements' locator {baseLocator} is not {ByXpathIdentifier}, and is not supported yet");
             return By.XPath(elementLocator);
         }

--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/ElementFactory.cs
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/ElementFactory.cs
@@ -16,6 +16,8 @@ namespace Aquality.Selenium.Core.Elements
     public class ElementFactory : IElementFactory
     {
         private const string ByXpathIdentifier = "By.XPath";
+        private const string ByTagNameIdentifier = "By.TagName";
+        private const string TagNameXPathPrefix = "//";
 
         public ElementFactory(IConditionalWait conditionalWait, IElementFinder elementFinder, ILocalizationManager localizationManager)
         {
@@ -40,12 +42,12 @@ namespace Aquality.Selenium.Core.Elements
         public virtual T FindChildElement<T>(IElement parentElement, By childLocator, string name = null, ElementSupplier<T> supplier = null, ElementState state = ElementState.Displayed) where T : IElement
         {
             var elementSupplier = ResolveSupplier(supplier);
-            return elementSupplier(new ByChained(parentElement.Locator, childLocator), name ?? $"Child element of {parentElement.Name}", state);
+            return elementSupplier(GenerateAbsoluteChildLocator(parentElement.Locator, childLocator), name ?? $"Child element of {parentElement.Name}", state);
         }
 
         public virtual IList<T> FindChildElements<T>(IElement parentElement, By childLocator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed) where T : IElement
         {
-            return FindElements(new ByChained(parentElement.Locator, childLocator), name ?? $"Child element of {parentElement.Name}", supplier, expectedCount, state);
+            return FindElements(GenerateAbsoluteChildLocator(parentElement.Locator, childLocator), name ?? $"Child element of {parentElement.Name}", supplier, expectedCount, state);
         }
 
         public virtual IList<T> FindElements<T>(By locator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed) where T : IElement
@@ -92,11 +94,63 @@ namespace Aquality.Selenium.Core.Elements
         /// <returns>target element's locator</returns>
         protected virtual By GenerateXpathLocator(By baseLocator, IWebElement webElement, int elementIndex)
         {
-            var strBaseLocator = baseLocator.ToString();
-            var elementLocator = strBaseLocator.StartsWith(ByXpathIdentifier)
-                    ? $"({strBaseLocator.Substring(strBaseLocator.IndexOf(':') + 1).Trim()})[{elementIndex}]"
-                    : throw new NotSupportedException($"Multiple elements' locator {baseLocator} is not {ByXpathIdentifier}, and is not supported yet");
+            var elementLocator = IsLocatorSupportedForXPathExtraction(baseLocator)
+                    ? $"({ExtractXPathFromLocator(baseLocator)})[{elementIndex}]"
+                    : throw new NotSupportedException($"Multiple elements' baseLocator type {baseLocator} is not supported yet");
             return By.XPath(elementLocator);
+        }
+
+        /// <summary>
+        /// Generates absolute child locator for target element.
+        /// </summary>
+        /// <param name="parentLocator">parent locator</param>
+        /// <param name="childLocator">child locator relative to parent</param>
+        /// <returns>absolute locator of the child</returns>
+        protected virtual By GenerateAbsoluteChildLocator(By parentLocator, By childLocator)
+        {
+            if (IsLocatorSupportedForXPathExtraction(parentLocator) && IsLocatorSupportedForXPathExtraction(childLocator))
+            {
+                var childLocatorString = ExtractXPathFromLocator(childLocator);
+                var parentLocatorString = ExtractXPathFromLocator(parentLocator);
+                return By.XPath(parentLocatorString +
+                    $"{(childLocatorString.StartsWith(".") ? childLocatorString.Substring(1) : childLocatorString)}");
+            }
+            return new ByChained(parentLocator, childLocator);
+        }
+
+        /// <summary>
+        /// Extracts XPath from passed locator.
+        /// Current implementation works only with ByXPath.class and ByTagName locator types,
+        /// but you can implement your own for the specific WebDriver type.
+        /// </summary>
+        /// <param name="locator">locator to get xpath from.</param>
+        /// <returns>extracted XPath.</returns>
+        protected virtual string ExtractXPathFromLocator(By locator)
+        {
+            var stringLocator = locator.ToString();
+            string getLocatorWithoutPrefix() => stringLocator.Substring(stringLocator.IndexOf(':') + 1).Trim();
+            if (stringLocator.StartsWith(ByXpathIdentifier))
+            {
+                return getLocatorWithoutPrefix();
+            }
+            if (stringLocator.StartsWith(ByTagNameIdentifier))
+            {
+                return $"{TagNameXPathPrefix}{getLocatorWithoutPrefix()}";
+            }
+
+            throw new NotSupportedException($"Cannot define xpath from locator {stringLocator}. Locator type is not supported yet");
+        }
+
+        /// <summary>
+        /// Defines is the locator can be transformed to xpath or not.
+        /// Current implementation works only with ByXPath.class and ByTagName locator types,
+        /// but you can implement your own for the specific WebDriver type.
+        /// </summary>
+        /// <param name="locator">locator to transform</param>
+        /// <returns>true if the locator can be transformed to xpath, false otherwise.</returns>
+        protected virtual bool IsLocatorSupportedForXPathExtraction(By locator)
+        {
+            return locator.ToString().StartsWith(ByXpathIdentifier) || locator.ToString().StartsWith(ByTagNameIdentifier);
         }
 
         /// <summary>

--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/Interfaces/IElementFactory.cs
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/Interfaces/IElementFactory.cs
@@ -40,6 +40,7 @@ namespace Aquality.Selenium.Core.Elements.Interfaces
         /// <param name="parentElement">Parent element.</param>
         /// <param name="childLocator">Locator of child elements relative to their parent.</param>
         /// <param name="supplier">Delegate that defines constructor of element in case of custom element type.</param>
+        /// <param name="expectedCount">Expected number of elements that have to be found (zero, more then zero, any).</param>
         /// <param name="state">Child elements state.</param>
         /// <param name="name">Child elements name.</param>
         /// <exception cref="InvalidOperationException">Thrown when the supplier is null, and no constructor with required arguments was found.</exception>

--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/Interfaces/IElementFactory.cs
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/Interfaces/IElementFactory.cs
@@ -34,9 +34,22 @@ namespace Aquality.Selenium.Core.Elements.Interfaces
         T FindChildElement<T>(IElement parentElement, By childLocator, string name = null, ElementSupplier<T> supplier = null, ElementState state = ElementState.Displayed) where T : IElement;
 
         /// <summary>
+        /// Finds list of child elements by their locator relative to parent element.
+        /// </summary>
+        /// <typeparam name="T">Type of child elements that has to implement IElement.</typeparam>
+        /// <param name="parentElement">Parent element.</param>
+        /// <param name="childLocator">Locator of child elements relative to their parent.</param>
+        /// <param name="supplier">Delegate that defines constructor of element in case of custom element type.</param>
+        /// <param name="state">Child elements state.</param>
+        /// <param name="name">Child elements name.</param>
+        /// <exception cref="InvalidOperationException">Thrown when the supplier is null, and no constructor with required arguments was found.</exception>
+        /// <returns>List of child elements.</returns>
+        IList<T> FindChildElements<T>(IElement parentElement, By childLocator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed) where T : IElement;
+
+        /// <summary>
         /// Finds list of elements by base locator.
         /// </summary>
-        /// <typeparam name="T">Type of elements that have to implement IElement.</typeparam>
+        /// <typeparam name="T">Type of elements that has to implement IElement.</typeparam>
         /// <param name="locator">Base elements locator.</param>
         /// <param name="supplier">Delegate that defines constructor of element in case of custom elements.</param>
         /// <param name="expectedCount">Expected number of elements that have to be found (zero, more then zero, any).</param>

--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/Interfaces/IParent.cs
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/Interfaces/IParent.cs
@@ -1,4 +1,5 @@
 ﻿using OpenQA.Selenium;
+using System.Collections.Generic;
 
 namespace Aquality.Selenium.Core.Elements.Interfaces
 {
@@ -17,5 +18,16 @@ namespace Aquality.Selenium.Core.Elements.Interfaces
         /// <param name="state">Child element state.</param>
         /// <returns>Instance of child element.</returns>
         T FindChildElement<T>(By childLocator, string name = null, ElementSupplier<T> supplier = null, ElementState state = ElementState.Displayed) where T : IElement;
+        
+        /// <summary>
+        /// Finds child elements of current element by its locator.
+        /// </summary>
+        /// <typeparam name="T">Type of child elements that has to implement IElement.</typeparam>
+        /// <param name="childLocator">Locator of child elements relative to their parent.</param>
+        /// <param name="name">Child elements name.</param>
+        /// <param name="supplier">Delegate that defines constructor of child element in case of custom element type.</param>
+        /// <param name="state">Child elements state.</param>
+        /// <returns>List of child elements.</returns>
+        IList<T> FindChildElements<T>(By childLocator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed) where T : IElement;
     }
 }

--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/Interfaces/IParent.cs
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/Interfaces/IParent.cs
@@ -18,7 +18,7 @@ namespace Aquality.Selenium.Core.Elements.Interfaces
         /// <param name="state">Child element state.</param>
         /// <returns>Instance of child element.</returns>
         T FindChildElement<T>(By childLocator, string name = null, ElementSupplier<T> supplier = null, ElementState state = ElementState.Displayed) where T : IElement;
-        
+
         /// <summary>
         /// Finds child elements of current element by its locator.
         /// </summary>
@@ -26,6 +26,7 @@ namespace Aquality.Selenium.Core.Elements.Interfaces
         /// <param name="childLocator">Locator of child elements relative to their parent.</param>
         /// <param name="name">Child elements name.</param>
         /// <param name="supplier">Delegate that defines constructor of child element in case of custom element type.</param>
+        /// <param name="expectedCount">Expected number of elements that have to be found (zero, more then zero, any).</param>
         /// <param name="state">Child elements state.</param>
         /// <returns>List of child elements.</returns>
         IList<T> FindChildElements<T>(By childLocator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed) where T : IElement;

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/AqualityServices.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/AqualityServices.cs
@@ -16,7 +16,18 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
 
         public static ChromeApplication Application => GetApplication(services => StartChrome(services));
 
-        public static IServiceProvider ServiceProvider => GetServiceProvider(services => Application);
+        public static IServiceProvider ServiceProvider 
+        { 
+            get
+            {
+                return GetServiceProvider(services => Application);
+            }
+            set
+            {
+                SetServiceProvider(value);
+            }
+        }
+            
 
         private static ChromeApplication StartChrome(IServiceProvider services)
         {

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/Elements/WebElementFactory.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/Elements/WebElementFactory.cs
@@ -1,0 +1,25 @@
+﻿using Aquality.Selenium.Core.Elements;
+using Aquality.Selenium.Core.Elements.Interfaces;
+using Aquality.Selenium.Core.Localization;
+using Aquality.Selenium.Core.Utilities;
+using Aquality.Selenium.Core.Waitings;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.Extensions;
+
+namespace Aquality.Selenium.Core.Tests.Applications.Browser.Elements
+{
+    internal class WebElementFactory : ElementFactory
+    {
+        public WebElementFactory(IConditionalWait conditionalWait, IElementFinder elementFinder, ILocalizationManager localizationManager) : base(conditionalWait, elementFinder, localizationManager)
+        {
+        }
+
+        protected override By GenerateXpathLocator(By baseLocator, IWebElement webElement, int elementIndex)
+        {
+            return baseLocator.ToString().StartsWith("By.XPath")
+                ? base.GenerateXpathLocator(baseLocator, webElement, elementIndex)
+                : By.XPath(AqualityServices.Application.Driver.ExecuteJavaScript<string>(
+                    FileReader.GetTextFromEmbeddedResource("Resources.GetElementXPath.js"), webElement));
+        }
+    }
+}

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/FindChildElementsTests.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/FindChildElementsTests.cs
@@ -1,0 +1,48 @@
+﻿using Aquality.Selenium.Core.Elements;
+using Aquality.Selenium.Core.Tests.Applications.WindowsApp.Elements;
+using NUnit.Framework;
+using OpenQA.Selenium;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Aquality.Selenium.Core.Tests.Applications.Browser
+{
+    public class FindChildElementsTests : FindElementsTests
+    {
+        private readonly Label customParent = new Label(By.XPath("//div[contains(@class,'figure')][1]"), "custom parent", ElementState.ExistsInAnyState);
+        protected override By HiddenElementsLoc => By.XPath(".//h5");
+        protected override By DisplayedElementsLoc => By.XPath(".//img[@alt='User Avatar']");
+        protected override By NotExistElementLoc => By.XPath(".//div[@class='testtest']");
+
+        protected override IList<T> FindElements<T>(By locator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed)
+        {
+            return elementFactory.FindChildElements(parentElement, locator, name, supplier, expectedCount, state);
+        }
+
+        [Test]
+        public void Should_GetCorrectNumberOfChilds_ForRelativeChildLocator()
+        {
+            var expectedCount = 1;
+            var elementsCount = elementFactory.FindChildElements<Label>(customParent, DisplayedElementsLoc).Count;
+            Assert.AreEqual(expectedCount, elementsCount, $"Elements count for relative locator should be {expectedCount}");
+        }
+
+        [Test]
+        public void Should_GetCorrectNumberOfChilds_ForAbsoluteChildLocator()
+        {
+            var expectedCount = 3;
+            var elementsCount = elementFactory.FindChildElements<Label>(customParent, base.DisplayedElementsLoc).Count;
+            Assert.AreEqual(expectedCount, elementsCount, $"Elements count for absolute locator should be {expectedCount}");
+        }
+
+        [Test]
+        public void Should_SetWorkableLocators_ToChildElements()
+        {
+            var foundElements = elementFactory.FindChildElements<Label>(customParent, base.DisplayedElementsLoc);
+            Assert.DoesNotThrow(() =>
+            {
+                foundElements.Select(element => element.GetElement()).ToList();
+            });
+        }
+    }
+}

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/FindChildElementsTests.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/FindChildElementsTests.cs
@@ -9,40 +9,67 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
 {
     public class FindChildElementsTests : FindElementsTests
     {
-        private readonly Label customParent = new Label(By.XPath("//div[contains(@class,'figure')][1]"), "custom parent", ElementState.ExistsInAnyState);
+        private readonly Label customParent = new Label(By.XPath("//div[contains(@class,'figure')]"), 
+            "custom parent", ElementState.ExistsInAnyState);
         protected override By HiddenElementsLoc => By.XPath(".//h5");
         protected override By DisplayedElementsLoc => By.XPath(".//img[@alt='User Avatar']");
         protected override By NotExistElementLoc => By.XPath(".//div[@class='testtest']");
 
-        protected override IList<T> FindElements<T>(By locator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed)
+        private static readonly By[] SupportedLocators = new By[]
+        {
+            By.XPath("//img"),
+            By.XPath(".//img"),
+            By.TagName("img")
+        };
+
+        protected override IList<T> FindElements<T>(By locator, string name = null, ElementSupplier<T> supplier = null, 
+            ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed)
         {
             return ParentElement.FindChildElements(locator, name, supplier, expectedCount, state);
         }
 
         [Test]
-        public void Should_GetCorrectNumberOfChilds_ForRelativeChildLocator()
-        {
-            var expectedCount = 1;
-            var elementsCount = ElementFactory.FindChildElements<Label>(customParent, DisplayedElementsLoc).Count;
-            Assert.AreEqual(expectedCount, elementsCount, $"Elements count for relative locator should be {expectedCount}");
-        }
-
-        [Test]
-        public void Should_GetCorrectNumberOfChilds_ForAbsoluteChildLocator()
+        public void Should_GetCorrectNumberOfChilds_ForRelativeChildLocator(
+            [ValueSource(nameof(SupportedLocators))] By childRelativeLocator)
         {
             var expectedCount = 3;
-            var elementsCount = ElementFactory.FindChildElements<Label>(customParent, base.DisplayedElementsLoc).Count;
-            Assert.AreEqual(expectedCount, elementsCount, $"Elements count for absolute locator should be {expectedCount}");
+            var elementsCount = ElementFactory.FindChildElements<Label>(customParent, childRelativeLocator).Count;
+            Assert.AreEqual(expectedCount, elementsCount, 
+                $"Elements count for relative locator [{childRelativeLocator}] should be {expectedCount}");
         }
 
         [Test]
-        public void Should_SetWorkableLocators_ToChildElements()
+        public void Should_SetWorkableLocators_ToChildElements([ValueSource(nameof(SupportedLocators))] By childRelativeLocator)
         {
-            var foundElements = ElementFactory.FindChildElements<Label>(customParent, base.DisplayedElementsLoc);
+            var foundElements = ElementFactory.FindChildElements<Label>(customParent, childRelativeLocator);
             Assert.DoesNotThrow(() =>
             {
                 foundElements.Select(element => element.GetElement()).ToList();
             });
+        }
+
+        [Test]
+        public void Should_SetXPathLocator_InFindChildElement_IfBothParentAndChildHaveSupportedLocators(
+            [ValueSource(nameof(SupportedLocators))] By childRelativeLocator)
+        {
+            var childLocatorString = customParent.FindChildElement<Label>(childRelativeLocator).Locator.ToString();
+            CheckChildLocatorIsXpathAndStartsFromParent(childLocatorString);
+        }
+
+        [Test]
+        public void Should_SetXPathLocator_InFindChildElements_IfBothParentAndChildHaveSupportedLocators(
+            [ValueSource(nameof(SupportedLocators))] By childRelativeLocator)
+        {
+            var childLocatorStrings = customParent.FindChildElements<Label>(childRelativeLocator)
+                .Select(child => child.Locator.ToString())
+                .ToList();
+            Assert.Multiple(() => childLocatorStrings.ForEach(CheckChildLocatorIsXpathAndStartsFromParent));            
+        }
+
+        private void CheckChildLocatorIsXpathAndStartsFromParent(string childLocatorString)
+        {
+            StringAssert.StartsWith("By.XPath", childLocatorString);
+            StringAssert.Contains(customParent.Locator.ToString(), childLocatorString);
         }
     }
 }

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/FindChildElementsTests.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/FindChildElementsTests.cs
@@ -16,14 +16,14 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
 
         protected override IList<T> FindElements<T>(By locator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed)
         {
-            return elementFactory.FindChildElements(parentElement, locator, name, supplier, expectedCount, state);
+            return ParentElement.FindChildElements(locator, name, supplier, expectedCount, state);
         }
 
         [Test]
         public void Should_GetCorrectNumberOfChilds_ForRelativeChildLocator()
         {
             var expectedCount = 1;
-            var elementsCount = elementFactory.FindChildElements<Label>(customParent, DisplayedElementsLoc).Count;
+            var elementsCount = ElementFactory.FindChildElements<Label>(customParent, DisplayedElementsLoc).Count;
             Assert.AreEqual(expectedCount, elementsCount, $"Elements count for relative locator should be {expectedCount}");
         }
 
@@ -31,14 +31,14 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
         public void Should_GetCorrectNumberOfChilds_ForAbsoluteChildLocator()
         {
             var expectedCount = 3;
-            var elementsCount = elementFactory.FindChildElements<Label>(customParent, base.DisplayedElementsLoc).Count;
+            var elementsCount = ElementFactory.FindChildElements<Label>(customParent, base.DisplayedElementsLoc).Count;
             Assert.AreEqual(expectedCount, elementsCount, $"Elements count for absolute locator should be {expectedCount}");
         }
 
         [Test]
         public void Should_SetWorkableLocators_ToChildElements()
         {
-            var foundElements = elementFactory.FindChildElements<Label>(customParent, base.DisplayedElementsLoc);
+            var foundElements = ElementFactory.FindChildElements<Label>(customParent, base.DisplayedElementsLoc);
             Assert.DoesNotThrow(() =>
             {
                 foundElements.Select(element => element.GetElement()).ToList();

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/FindChildElementsTests.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/FindChildElementsTests.cs
@@ -69,7 +69,8 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
         private void CheckChildLocatorIsXpathAndStartsFromParent(string childLocatorString)
         {
             StringAssert.StartsWith("By.XPath", childLocatorString);
-            StringAssert.Contains(customParent.Locator.ToString(), childLocatorString);
+            var parentLocatorString = customParent.Locator.ToString();
+            StringAssert.Contains(parentLocatorString.Substring(parentLocatorString.IndexOf(':') + 1).Trim(), childLocatorString);
         }
     }
 }

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/FindElementsTests.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/FindElementsTests.cs
@@ -12,29 +12,29 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
 {
     public class FindElementsTests : TestWithBrowser
     {
+        private static readonly By ContentLoc = By.XPath("//div[contains(@class,'example')]");
+        private static readonly Uri HoversURL = new Uri($"{TestSite}/hovers");
+
         protected virtual By HiddenElementsLoc => By.XPath("//h5");
         protected virtual By DisplayedElementsLoc => By.XPath("//img[@alt='User Avatar']");
         protected virtual By DottedLoc => By.XPath("//img[@alt='User Avatar']/parent::div");
         protected virtual By NotExistElementLoc => By.XPath("//div[@class='testtest']");
-
-        private static readonly By ContentLoc = By.XPath("//div[contains(@class,'example')]");
-        private static readonly Uri HoversURL = new Uri($"{TestSite}/hovers");
         
-        protected static IElementFactory elementFactory;
-        protected static Label parentElement;
+        protected IElementFactory ElementFactory { get; private set; }
+        protected Label ParentElement { get; private set; }
 
         protected virtual IList<T> FindElements<T>(By locator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed) where T : IElement
         {
-            return elementFactory.FindElements(locator, name, supplier, expectedCount, state);
+            return ElementFactory.FindElements(locator, name, supplier, expectedCount, state);
         }
 
         [SetUp]
         public new void SetUp()
         {
-            elementFactory = ServiceProvider.GetRequiredService<IElementFactory>();
+            ElementFactory = ServiceProvider.GetRequiredService<IElementFactory>();
             AqualityServices.Application.Driver.Navigate().GoToUrl(HoversURL);
-            parentElement = new Label(ContentLoc, "Example", ElementState.Displayed);
-            parentElement.Click();
+            ParentElement = new Label(ContentLoc, "Example", ElementState.Displayed);
+            ParentElement.Click();
         }
 
         [TestCase(ElementsCount.MoreThenZero, ElementState.Displayed, 3)]

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/FindElementsTests.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/FindElementsTests.cs
@@ -5,26 +5,36 @@ using Aquality.Selenium.Core.Elements.Interfaces;
 using Aquality.Selenium.Core.Tests.Applications.WindowsApp.Elements;
 using Microsoft.Extensions.DependencyInjection;
 using OpenQA.Selenium;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Aquality.Selenium.Core.Tests.Applications.Browser
 {
     public class FindElementsTests : TestWithBrowser
     {
-        private static readonly By HiddenElementsLoc = By.XPath("//h5");
-        private static readonly By DisplayedElementsLoc = By.XPath("//img[@alt='User Avatar']");
-        private static readonly By NotExistElementLoc = By.XPath("//div[@class='testtest']");
+        protected virtual By HiddenElementsLoc => By.XPath("//h5");
+        protected virtual By DisplayedElementsLoc => By.XPath("//img[@alt='User Avatar']");
+        protected virtual By DottedLoc => By.XPath("//img[@alt='User Avatar']/parent::div");
+        protected virtual By NotExistElementLoc => By.XPath("//div[@class='testtest']");
+
         private static readonly By ContentLoc = By.XPath("//div[contains(@class,'example')]");
         private static readonly Uri HoversURL = new Uri($"{TestSite}/hovers");
+        
+        protected static IElementFactory elementFactory;
+        protected static Label parentElement;
 
-        private IElementFactory elementFactory;
+        protected virtual IList<T> FindElements<T>(By locator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed) where T : IElement
+        {
+            return elementFactory.FindElements(locator, name, supplier, expectedCount, state);
+        }
 
         [SetUp]
         public new void SetUp()
         {
             elementFactory = ServiceProvider.GetRequiredService<IElementFactory>();
             AqualityServices.Application.Driver.Navigate().GoToUrl(HoversURL);
-            var example = new Label(ContentLoc, "Example", ElementState.Displayed);
-            example.Click();
+            parentElement = new Label(ContentLoc, "Example", ElementState.Displayed);
+            parentElement.Click();
         }
 
         [TestCase(ElementsCount.MoreThenZero, ElementState.Displayed, 3)]
@@ -33,7 +43,7 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
         [TestCase(ElementsCount.Any, ElementState.ExistsInAnyState, 3)]
         public void Should_BePossibleTo_FindElements_ForDisplayedElements(ElementsCount count, ElementState state, int expectedCount)
         {
-            var elementsCount = elementFactory.FindElements<Label>(DisplayedElementsLoc, expectedCount: count, state: state).Count;
+            var elementsCount = FindElements<Label>(DisplayedElementsLoc, expectedCount: count, state: state).Count;
             Assert.AreEqual(expectedCount, elementsCount, $"Elements count for displayed elements should be {expectedCount}");
         }
 
@@ -43,7 +53,7 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
         [TestCase(ElementsCount.Any, ElementState.ExistsInAnyState, 3)]
         public void Should_BePossibleTo_FindElements_ForHiddenElements(ElementsCount count, ElementState state, int expectedCount)
         {
-            var elementsCount = elementFactory.FindElements<Label>(HiddenElementsLoc, expectedCount: count, state: state).Count;
+            var elementsCount = FindElements<Label>(HiddenElementsLoc, expectedCount: count, state: state).Count;
             Assert.AreEqual(expectedCount, elementsCount, $"Elements count for hidden elements should be {expectedCount}");
         }
 
@@ -53,7 +63,7 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
         [TestCase(ElementsCount.Any, ElementState.ExistsInAnyState, 0)]
         public void Should_BePossibleTo_FindElements_ForNotExistsElements(ElementsCount count, ElementState state, int expectedCount)
         {
-            var elementsCount = elementFactory.FindElements<Label>(NotExistElementLoc, expectedCount: count, state: state).Count;
+            var elementsCount = FindElements<Label>(NotExistElementLoc, expectedCount: count, state: state).Count;
             Assert.AreEqual(expectedCount, elementsCount, $"Elements count for not existing elements should be {expectedCount}");
         }
 
@@ -62,7 +72,7 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
         public void Should_BeImpossibleTo_FindDisplayedElements_WithWrongArguments(ElementsCount count, ElementState state)
         {
             Assert.Throws<TimeoutException>(
-                () => elementFactory.FindElements<Label>(DisplayedElementsLoc, expectedCount: count, state: state),
+                () => FindElements<Label>(DisplayedElementsLoc, expectedCount: count, state: state),
                 $"Tried to find elements with expected count '{count}' and state '{state}'");
         }
 
@@ -71,7 +81,7 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
         public void Should_BeImpossibleTo_FindHiddenElements_WithWrongArguments(ElementsCount count, ElementState state)
         {
             Assert.Throws<TimeoutException>(
-                () => elementFactory.FindElements<Label>(HiddenElementsLoc, expectedCount: count, state: state),
+                () => FindElements<Label>(HiddenElementsLoc, expectedCount: count, state: state),
                 $"Tried to find elements with expected count '{count}' and state '{state}'");
         }
 
@@ -80,8 +90,17 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
         public void Should_BeImpossibleTo_FindNotExistElements_WithWrongArguments(ElementsCount count, ElementState state)
         {
             Assert.Throws<TimeoutException>(
-                () => elementFactory.FindElements<Label>(NotExistElementLoc, expectedCount: count, state: state),
+                () => FindElements<Label>(NotExistElementLoc, expectedCount: count, state: state),
                 $"Tried to find elements with expected count '{count}' and state '{state}'");
+        }
+
+        [Test]
+        public void Should_BePossibleTo_WorkWithElements_FoundByDottedLocator()
+        {
+            var foundElements = FindElements<Label>(DottedLoc, expectedCount: ElementsCount.MoreThenZero);
+            Assert.DoesNotThrow(
+                () => foundElements.Select(element => element.GetElement()).ToList(),
+                $"Failed to find elements using dotted locator [{DottedLoc}]");
         }
     }
 }

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/TestWithBrowser.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/TestWithBrowser.cs
@@ -1,6 +1,10 @@
 ﻿using Aquality.Selenium.Core.Applications;
+using Aquality.Selenium.Core.Configurations;
+using Aquality.Selenium.Core.Elements.Interfaces;
+using Aquality.Selenium.Core.Tests.Applications.Browser.Elements;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
+using System;
 
 namespace Aquality.Selenium.Core.Tests.Applications.Browser
 {
@@ -17,7 +21,7 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
         {
             var services = new ServiceCollection();
 
-            new Startup().ConfigureServices(services, serviceCollection => AqualityServices.Application);
+            new CustomStartup().ConfigureServices(services, serviceCollection => AqualityServices.Application);
             ServiceProvider = services.BuildServiceProvider();
         }
 
@@ -27,6 +31,16 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
             if (AqualityServices.IsApplicationStarted)
             {
                 AqualityServices.Application.Quit();
+            }
+        }
+
+        private class CustomStartup : Startup
+        {
+            public override IServiceCollection ConfigureServices(IServiceCollection services, Func<IServiceProvider, IApplication> applicationProvider, ISettingsFile settings = null)
+            {
+                base.ConfigureServices(services, applicationProvider, settings);
+                services.AddSingleton<IElementFactory, WebElementFactory>();
+                return services;
             }
         }
     }

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/TestWithBrowser.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/TestWithBrowser.cs
@@ -23,6 +23,7 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
 
             new CustomStartup().ConfigureServices(services, serviceCollection => AqualityServices.Application);
             ServiceProvider = services.BuildServiceProvider();
+            AqualityServices.ServiceProvider = ServiceProvider;
         }
 
         [TearDown]

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Aquality.Selenium.Core.Tests.csproj
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Aquality.Selenium.Core.Tests.csproj
@@ -7,11 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Resources\GetElementXPath.js" />
     <None Remove="Resources\settings.embeddedresource.json" />
     <None Remove="Resources\settings.special.json" />
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="Resources\GetElementXPath.js" />
     <EmbeddedResource Include="Resources\settings.embeddedresource.json">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </EmbeddedResource>

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Resources/GetElementXPath.js
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Resources/GetElementXPath.js
@@ -1,0 +1,25 @@
+function getXpath(element) {
+    if (element.tagName === 'HTML') {
+        return '/html';
+    }
+    if (element === document.body) {
+        return '/html/body';
+    }
+    // calculate position among siblings
+    let position = 0;
+    // Gets all siblings of that element.
+    let siblings = element.parentNode.childNodes;
+    for (let i = 0; i < siblings.length; i++) {
+        let sibling = siblings[i];
+        // Check sibling with our element if match then recursively call for its parent element.
+        if (sibling === element) {
+            return `${getXpath(element.parentNode)}/${element.tagName}[${position + 1}]`;
+        }
+        // if it is a sibling & element-node then only increments position.
+        let type = sibling.nodeType;
+        if (type === 1 && sibling.tagName === element.tagName) {
+            position++;
+        }
+    }
+}
+return getXpath(arguments[0]);


### PR DESCRIPTION
Implement FindChildElements in IElementsFactory, resolves #67.
Fix GenerateXPathLocator method for ByChained type of locator.
Fixes #71 (dotted xpath locator split issue).