### PR TITLE
Fixed CachedElementStateProvider behaviour: IsEnabled and related functions should throw NoSuchElementException

### DIFF
--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/CachedElementStateProvider.cs
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Elements/CachedElementStateProvider.cs
@@ -24,15 +24,16 @@ namespace Aquality.Selenium.Core.Elements
 
         protected virtual IList<Type> HandledExceptions => new List<Type> { typeof(StaleElementReferenceException), typeof(NoSuchElementException) };
 
-        protected virtual bool TryInvokeFunction(Func<IWebElement, bool> func)
+        protected virtual bool TryInvokeFunction(Func<IWebElement, bool> func, IList<Type> exceptionsToHandle = null)
         {
+            var handledExceptions = exceptionsToHandle ?? HandledExceptions;
             try
             {
                 return func(elementCacheHandler.GetElement(TimeSpan.Zero, ElementState.ExistsInAnyState));
             }
             catch (Exception e)
             {
-                if (HandledExceptions.Any(type => type.IsAssignableFrom(e.GetType())))
+                if (handledExceptions.Any(type => type.IsAssignableFrom(e.GetType())))
                 {
                     return false;
                 }
@@ -46,7 +47,7 @@ namespace Aquality.Selenium.Core.Elements
 
         public virtual bool IsClickable => TryInvokeFunction(element => element.Displayed && element.Enabled);
 
-        public virtual bool IsEnabled => TryInvokeFunction(element => element.Enabled);
+        public virtual bool IsEnabled => TryInvokeFunction(element => element.Enabled, new[] { typeof(StaleElementReferenceException) });
 
         public virtual void WaitForClickable(TimeSpan? timeout = null)
         {

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/CachedElementTests.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/CachedElementTests.cs
@@ -140,12 +140,11 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
             var testElement = new Label(ContentLoc, "Example", ElementState.ExistsInAnyState);
             testElement.State.WaitForClickable();
             AqualityServices.Application.Quit();
+            StartLoading();
+            ConditionalWait.WaitForTrue(() => testElement.Cache.IsStale, message: "Element should be stale after page is closed.");
             OpenDynamicContent();
-            ConditionalWait.WaitForTrue(() => testElement.Cache.IsStale, message: "Element should be stale after page is reopened.");
-            AqualityServices.Application.Driver.Navigate().Refresh();
-            Assert.IsTrue(testElement.Cache.IsStale, "Element should remain stale after the page refresh.");
             Assert.AreEqual(expectedValue, stateCondition(testElement.State), 
-                "Element state condition is not expected after refreshing the window");            
+                "Element state condition is not expected after reopening the window");            
         }
 
         [TearDown]

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/CachedElementTests.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/Browser/CachedElementTests.cs
@@ -40,6 +40,14 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
                 state => !state.WaitForNotEnabled(TimeSpan.Zero),
             };
 
+        private static readonly Func<IElementStateProvider, bool>[] StateFunctionsThrowNoSuchElementException
+            = new Func<IElementStateProvider, bool>[]
+            {
+                state => state.IsEnabled,
+                state => state.WaitForEnabled(TimeSpan.Zero),
+                state => !state.WaitForNotEnabled(TimeSpan.Zero),
+            };
+
         private IConditionalWait ConditionalWait => AqualityServices.ServiceProvider.GetRequiredService<IConditionalWait>();
 
         [SetUp]
@@ -108,26 +116,32 @@ namespace Aquality.Selenium.Core.Tests.Applications.Browser
         }
         
         [Test]
-        [Ignore("Tests should be updated: find out more stable example")]
-        public void Should_ReturnCorrectState_False_WhenWindowIsRefreshed([ValueSource(nameof(StateFunctionsFalseWhenElementStale))] Func<IElementStateProvider, bool> stateCondition)
+        public void Should_ThrowNoSuchElementException_ForAbsentElement([ValueSource(nameof(StateFunctionsThrowNoSuchElementException))] Func<IElementStateProvider, bool> stateCondition)
+        { 
+            var label = new Label(By.Name("Absent element"), "Absent element", ElementState.Displayed);
+            Assert.Throws<NoSuchElementException>(() => stateCondition.Invoke(label.State));
+        }
+        
+        [Test]
+        public void Should_ReturnCorrectState_False_WhenWindowIsReopened([ValueSource(nameof(StateFunctionsFalseWhenElementStale))] Func<IElementStateProvider, bool> stateCondition)
         {
-            AssertStateConditionAfterRefresh(stateCondition, expectedValue: false);
+            AssertStateConditionAfterReopen(stateCondition, expectedValue: false);
         }
 
         [Test]
-        [Ignore("Tests should be updated: find out more stable example")]
-        public void Should_ReturnCorrectState_True_WhenWindowIsRefreshed([ValueSource(nameof(StateFunctionsTrueWhenElementStaleWhichRetriveElement))] Func<IElementStateProvider, bool> stateCondition)
+        public void Should_ReturnCorrectState_True_WhenWindowIsReopened([ValueSource(nameof(StateFunctionsTrueWhenElementStaleWhichRetriveElement))] Func<IElementStateProvider, bool> stateCondition)
         {
-            AssertStateConditionAfterRefresh(stateCondition, expectedValue: true);
+            AssertStateConditionAfterReopen(stateCondition, expectedValue: true);
         }
 
-        private void AssertStateConditionAfterRefresh(Func<IElementStateProvider, bool> stateCondition, bool expectedValue)
+        private void AssertStateConditionAfterReopen(Func<IElementStateProvider, bool> stateCondition, bool expectedValue)
         {
             OpenDynamicContent();
             var testElement = new Label(ContentLoc, "Example", ElementState.ExistsInAnyState);
             testElement.State.WaitForClickable();
-            new Label(RemoveButtonLoc, "Remove", ElementState.Displayed).Click();
-            ConditionalWait.WaitForTrue(() => testElement.Cache.IsStale, message: "Element should be stale when it disappeared.");
+            AqualityServices.Application.Quit();
+            OpenDynamicContent();
+            ConditionalWait.WaitForTrue(() => testElement.Cache.IsStale, message: "Element should be stale after page is reopened.");
             AqualityServices.Application.Driver.Navigate().Refresh();
             Assert.IsTrue(testElement.Cache.IsStale, "Element should remain stale after the page refresh.");
             Assert.AreEqual(expectedValue, stateCondition(testElement.State), 

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/WindowsApp/CachedElementTests.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/WindowsApp/CachedElementTests.cs
@@ -3,6 +3,7 @@ using Aquality.Selenium.Core.Tests.Applications.WindowsApp.Elements;
 using Aquality.Selenium.Core.Tests.Applications.WindowsApp.Locators;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
+using OpenQA.Selenium;
 using System;
 
 namespace Aquality.Selenium.Core.Tests.Applications.WindowsApp
@@ -29,6 +30,14 @@ namespace Aquality.Selenium.Core.Tests.Applications.WindowsApp
                 state => state.IsClickable,
                 state => state.WaitForDisplayed(TimeSpan.Zero),
                 state => state.WaitForExist(TimeSpan.Zero),
+                state => state.WaitForEnabled(TimeSpan.Zero),
+                state => !state.WaitForNotEnabled(TimeSpan.Zero),
+            };
+
+        private static readonly Func<IElementStateProvider, bool>[] StateFunctionsThrowNoSuchElementException
+            = new Func<IElementStateProvider, bool>[]
+            {
+                state => state.IsEnabled,
                 state => state.WaitForEnabled(TimeSpan.Zero),
                 state => !state.WaitForNotEnabled(TimeSpan.Zero),
             };
@@ -83,6 +92,13 @@ namespace Aquality.Selenium.Core.Tests.Applications.WindowsApp
             oneButton.State.WaitForClickable();
             var resultElement = oneButton.GetElement().ToString();
             Assert.AreNotEqual(initialElement, resultElement, errorMessage);
+        }
+
+        [Test]
+        public void Should_ThrowNoSuchElementException_ForAbsentElement([ValueSource(nameof(StateFunctionsThrowNoSuchElementException))] Func<IElementStateProvider, bool> stateCondition)
+        {
+            var button = Factory.GetButton(CalculatorWindow.AbsentElement, "Absent element");
+            Assert.Throws<NoSuchElementException>(() => stateCondition.Invoke(button.State));
         }
 
         [Test]

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/WindowsApp/Locators/CalculatorWindow.cs
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Applications/WindowsApp/Locators/CalculatorWindow.cs
@@ -20,5 +20,7 @@ namespace Aquality.Selenium.Core.Tests.Applications.WindowsApp.Locators
         public static By ResultsLabel => MobileBy.AccessibilityId("48");
 
         public static By EmptyButton => By.XPath("//*[@AutomationId='7']");
+
+        public static By AbsentElement => By.Name("Absent element");
     }
 }


### PR DESCRIPTION
Fixed CachedElementStateProvider behaviour: IsEnabled and related functions should throw NoSuchElementException when the element is absent.
Fixes #57. Also closes #62 