### PR TITLE
Update Selenium to 4.23.0

### DIFF
--- a/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Aquality.Selenium.Core.csproj
+++ b/Aquality.Selenium.Core/src/Aquality.Selenium.Core/Aquality.Selenium.Core.csproj
@@ -51,8 +51,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageReference Include="NLog" Version="5.3.2" />
-    <PackageReference Include="Selenium.Support" Version="4.21.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.21.0" />
+    <PackageReference Include="Selenium.Support" Version="4.23.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.23.0" />
     <PackageReference Include="SkiaSharp" Version="2.88.8" />    
   </ItemGroup>
 </Project>

--- a/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Aquality.Selenium.Core.Tests.csproj
+++ b/Aquality.Selenium.Core/tests/Aquality.Selenium.Core.Tests/Aquality.Selenium.Core.Tests.csproj
@@ -25,10 +25,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Appium.WebDriver" Version="5.0.0" />
+    <PackageReference Include="Appium.WebDriver" Version="5.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="nunit" Version="4.1.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Appium added support for ExecuteAsync method from version 5.1.0, so now finally we can update to Selenium 4.23.0 without build issues